### PR TITLE
Rework ComputationReaction to run on Dispatchers.Default by default

### DIFF
--- a/example/src/main/java/com/github/whyrising/recompose/example/App.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/App.kt
@@ -6,6 +6,7 @@ class App : Application() {
   override fun onCreate() {
     super.onCreate()
     System.setProperty("kotlinx.coroutines.debug", "on")
+    // Log.i("currentThread$newInput", Thread.currentThread().name)
 
     initAppDb()
   }

--- a/example/src/main/java/com/github/whyrising/recompose/example/main.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/main.kt
@@ -130,8 +130,10 @@ class MainActivity : ComponentActivity() {
     regAllCofx()
     regAllFx(lifecycle.coroutineScope)
     setContent {
+      SideEffect {
+        dispatch(v(startTicking))
+      }
       regAllSubs(MaterialTheme.colors)
-      dispatch(v(startTicking))
       MyApp()
     }
   }

--- a/example/src/main/java/com/github/whyrising/recompose/example/subs/subs.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/subs/subs.kt
@@ -16,6 +16,8 @@ import com.github.whyrising.recompose.regSubM
 import com.github.whyrising.recompose.subs.Query
 import com.github.whyrising.recompose.subscribe
 import com.github.whyrising.y.core.v
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -60,8 +62,7 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub<Date, String>(
     queryId = formattedTime,
-//        context = Dispatchers.Default,
-//        placeholder = "...",
+    placeholder = "...",
     signalsFn = { subscribe(v(time)) }
   ) { date: Date, _: Query ->
     val formattedTime = SimpleDateFormat(HH_MM_SS, Locale.getDefault())
@@ -79,6 +80,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub(
     queryId = primaryColor,
+    placeholder = Color.Gray,
+//    context = Dispatchers.Main.immediate,
     signalsFn = { subscribe<String>(v(primaryColorStr)) }
   ) { colorName, _ ->
     toColor(colorName)
@@ -86,6 +89,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub(
     queryId = secondaryColor,
+    placeholder = Color.Gray,
+//    context = Dispatchers.Main.immediate,
     signalsFn = { subscribe<String>(v(secondaryColorStr)) }
   ) { colorName, _ ->
     toColor(colorName)
@@ -93,6 +98,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSubM(
     queryId = themeColors,
+    placeholder = defaultColors,
+//    context = Dispatchers.Main.immediate,
     signalsFn = {
       v(
         subscribe(v(primaryColor)),
@@ -100,9 +107,11 @@ fun regAllSubs(defaultColors: Colors) {
       )
     }
   ) { (primary, secondary), (_, colors) ->
-    (colors as Colors).copy(
-      primary = primary as Color,
-      secondary = secondary as Color
-    )
+    withContext(Dispatchers.Main.immediate) {
+      (colors as Colors).copy(
+        primary = primary as Color,
+        secondary = secondary as Color
+      )
+    }
   }
 }

--- a/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
+++ b/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
@@ -9,9 +9,9 @@ import com.github.whyrising.y.core.collections.PersistentVector
 import com.github.whyrising.y.core.get
 import com.github.whyrising.y.core.m
 import com.github.whyrising.y.core.v
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 internal const val stateKey = "state"
@@ -25,27 +25,21 @@ fun <T> deref(refs: IPersistentVector<IDeref<T>>): PersistentVector<T> =
 /**
  * @param inputSignals are the nodes (Reactions) that signal the current
  * [ComputationReaction] to recalculate its value when new values are provided.
- * @param initial when it's null, the first value calculation of this [ComputationReaction]
- * happens on the main thread.
- * @param context on which further values' calculations of this [ComputationReaction]
- * will happen.
+ * @param initial when it's null, the first value calculation of this
+ * [ComputationReaction] happens on the main thread.
+ * @param context on which further values' calculations of this
+ * [ComputationReaction] will happen.
  * @param f is the function that calculates the sequence of values of this
  * [ComputationReaction].
  */
 class ComputationReaction<I, O>(
   inputSignals: IPersistentVector<Reaction<I>>,
   val context: CoroutineContext,
-  private val initial: O?,
-  val f: (signalsValues: IPersistentVector<I>) -> O
+  private val initial: O,
+  val f: suspend (signalsValues: IPersistentVector<I>) -> O
 ) : ReactionBase<IPersistentMap<Any, Any?>, O>() {
   override val state: MutableStateFlow<IPersistentMap<Any, Any?>> by lazy {
-    val inputs = deref(inputSignals)
-    initState(
-      m<String, Any?>(
-        inputsKey to inputs,
-        stateKey to (initial ?: f(inputs))
-      )
-    )
+    initState(m<String, Any?>(stateKey to initial))
   }
 
   private fun isSameInput(
@@ -54,22 +48,17 @@ class ComputationReaction<I, O>(
     newInput: I
   ) = currentInputs.count > index && currentInputs[index] == newInput
 
-  private fun isStateSetToDefault(currentState: IPersistentMap<Any, Any?>) =
-    currentState[stateKey] != initial
-
   internal suspend fun recompute(input: I, inputIndex: Int) {
     while (true) {
       val currState = state.value
       val currInputs = currState[inputsKey] as PersistentVector<I>? ?: v()
 
-      if (isSameInput(currInputs, inputIndex, input) &&
-        isStateSetToDefault(currState)
-      ) {
+      if (isSameInput(currInputs, inputIndex, input)) {
         return
       }
 
       val newInputs = currInputs.assoc(inputIndex, input)
-      val materializedView = withContext(context) { f(newInputs) }
+      val materializedView = f(newInputs)
       val newState = m(stateKey to materializedView, inputsKey to newInputs)
 
       if (state.compareAndSet(currState, newState)) {
@@ -80,12 +69,19 @@ class ComputationReaction<I, O>(
 
   // init should be after state property.
   init {
-    for ((i, inputNode) in inputSignals.withIndex())
-      viewModelScope.launch {
-        inputNode.collect { newInput: I ->
-          recompute(newInput, i)
+    viewModelScope.launch(context) {
+      val inputs = deref(inputSignals)
+      state.value = m(
+        inputsKey to inputs,
+        stateKey to f(inputs)
+      )
+      for ((i, inputNode) in inputSignals.withIndex())
+        viewModelScope.launch(Dispatchers.Default) {
+          inputNode.collect { newInput: I ->
+            recompute(newInput, i)
+          }
         }
-      }
+    }
   }
 
   override fun deref(state: State<IPersistentMap<Any, Any?>>): O =

--- a/recompose/src/main/java/com/github/whyrising/recompose/subs/subs.kt
+++ b/recompose/src/main/java/com/github/whyrising/recompose/subs/subs.kt
@@ -75,9 +75,9 @@ inline fun <I, O> regCompSubscription(
   crossinline signalsFn: (
     queryVec: Query
   ) -> IPersistentVector<Reaction<I>>,
-  initial: O?,
+  initial: O,
   context: CoroutineContext,
-  crossinline computationFn: (
+  crossinline computationFn: suspend (
     subscriptions: IPersistentVector<I>,
     queryVec: Query
   ) -> O


### PR DESCRIPTION
Running them on the Main thread caused some animations to stutter (e.g. Circular Progress Loader). Providing a placeholder value and calculating the actual value asynchronously on Dispatchers.Default gives the UI the chance to do what it does best, render graphics smoothly.