### PR TITLE
Rework ComputationReaction to run on Dispatchers.Default by default

### DIFF
--- a/example/src/main/java/com/github/whyrising/recompose/example/App.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/App.kt
@@ -6,6 +6,7 @@ class App : Application() {
   override fun onCreate() {
     super.onCreate()
     System.setProperty("kotlinx.coroutines.debug", "on")
+    // Log.i("currentThread$newInput", Thread.currentThread().name)
 
     initAppDb()
   }

--- a/example/src/main/java/com/github/whyrising/recompose/example/main.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/main.kt
@@ -130,8 +130,10 @@ class MainActivity : ComponentActivity() {
     regAllCofx()
     regAllFx(lifecycle.coroutineScope)
     setContent {
+      SideEffect {
+        dispatch(v(startTicking))
+      }
       regAllSubs(MaterialTheme.colors)
-      dispatch(v(startTicking))
       MyApp()
     }
   }

--- a/example/src/main/java/com/github/whyrising/recompose/example/subs/subs.kt
+++ b/example/src/main/java/com/github/whyrising/recompose/example/subs/subs.kt
@@ -16,6 +16,8 @@ import com.github.whyrising.recompose.regSubM
 import com.github.whyrising.recompose.subs.Query
 import com.github.whyrising.recompose.subscribe
 import com.github.whyrising.y.core.v
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -60,8 +62,7 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub<Date, String>(
     queryId = formattedTime,
-//        context = Dispatchers.Default,
-//        placeholder = "...",
+    placeholder = "...",
     signalsFn = { subscribe(v(time)) }
   ) { date: Date, _: Query ->
     val formattedTime = SimpleDateFormat(HH_MM_SS, Locale.getDefault())
@@ -79,6 +80,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub(
     queryId = primaryColor,
+    placeholder = Color.Gray,
+//    context = Dispatchers.Main.immediate,
     signalsFn = { subscribe<String>(v(primaryColorStr)) }
   ) { colorName, _ ->
     toColor(colorName)
@@ -86,6 +89,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSub(
     queryId = secondaryColor,
+    placeholder = Color.Gray,
+//    context = Dispatchers.Main.immediate,
     signalsFn = { subscribe<String>(v(secondaryColorStr)) }
   ) { colorName, _ ->
     toColor(colorName)
@@ -93,6 +98,8 @@ fun regAllSubs(defaultColors: Colors) {
 
   regSubM(
     queryId = themeColors,
+    placeholder = defaultColors,
+//    context = Dispatchers.Main.immediate,
     signalsFn = {
       v(
         subscribe(v(primaryColor)),
@@ -100,9 +107,11 @@ fun regAllSubs(defaultColors: Colors) {
       )
     }
   ) { (primary, secondary), (_, colors) ->
-    (colors as Colors).copy(
-      primary = primary as Color,
-      secondary = secondary as Color
-    )
+    withContext(Dispatchers.Main.immediate) {
+      (colors as Colors).copy(
+        primary = primary as Color,
+        secondary = secondary as Color
+      )
+    }
   }
 }

--- a/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
+++ b/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
@@ -36,6 +36,7 @@ class ComputationReaction<I, O>(
   inputSignals: IPersistentVector<Reaction<I>>,
   val context: CoroutineContext,
   private val initial: O,
+  private val context2: CoroutineContext = Dispatchers.Default,
   val f: suspend (signalsValues: IPersistentVector<I>) -> O
 ) : ReactionBase<IPersistentMap<Any, Any?>, O>() {
   override val state: MutableStateFlow<IPersistentMap<Any, Any?>> by lazy {
@@ -76,7 +77,7 @@ class ComputationReaction<I, O>(
         stateKey to f(inputs)
       )
       for ((i, inputNode) in inputSignals.withIndex())
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch(context2) {
           inputNode.collect { newInput: I ->
             recompute(newInput, i)
           }

--- a/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
+++ b/recompose/src/main/java/com/github/whyrising/recompose/subs/ComputationReaction.kt
@@ -9,9 +9,9 @@ import com.github.whyrising.y.core.collections.PersistentVector
 import com.github.whyrising.y.core.get
 import com.github.whyrising.y.core.m
 import com.github.whyrising.y.core.v
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 internal const val stateKey = "state"
@@ -25,27 +25,21 @@ fun <T> deref(refs: IPersistentVector<IDeref<T>>): PersistentVector<T> =
 /**
  * @param inputSignals are the nodes (Reactions) that signal the current
  * [ComputationReaction] to recalculate its value when new values are provided.
- * @param initial when it's null, the first value calculation of this [ComputationReaction]
- * happens on the main thread.
- * @param context on which further values' calculations of this [ComputationReaction]
- * will happen.
+ * @param initial when it's null, the first value calculation of this
+ * [ComputationReaction] happens on the main thread.
+ * @param context on which further values' calculations of this
+ * [ComputationReaction] will happen.
  * @param f is the function that calculates the sequence of values of this
  * [ComputationReaction].
  */
 class ComputationReaction<I, O>(
   inputSignals: IPersistentVector<Reaction<I>>,
   val context: CoroutineContext,
-  private val initial: O?,
-  val f: (signalsValues: IPersistentVector<I>) -> O
+  private val initial: O,
+  val f: suspend (signalsValues: IPersistentVector<I>) -> O
 ) : ReactionBase<IPersistentMap<Any, Any?>, O>() {
   override val state: MutableStateFlow<IPersistentMap<Any, Any?>> by lazy {
-    val inputs = deref(inputSignals)
-    initState(
-      m<String, Any?>(
-        inputsKey to inputs,
-        stateKey to (initial ?: f(inputs))
-      )
-    )
+    initState(m<String, Any?>(stateKey to initial))
   }
 
   private fun isSameInput(
@@ -54,22 +48,17 @@ class ComputationReaction<I, O>(
     newInput: I
   ) = currentInputs.count > index && currentInputs[index] == newInput
 
-  private fun isStateSetToDefault(currentState: IPersistentMap<Any, Any?>) =
-    currentState[stateKey] != initial
-
   internal suspend fun recompute(input: I, inputIndex: Int) {
     while (true) {
       val currState = state.value
       val currInputs = currState[inputsKey] as PersistentVector<I>? ?: v()
 
-      if (isSameInput(currInputs, inputIndex, input) &&
-        isStateSetToDefault(currState)
-      ) {
+      if (isSameInput(currInputs, inputIndex, input)) {
         return
       }
 
       val newInputs = currInputs.assoc(inputIndex, input)
-      val materializedView = withContext(context) { f(newInputs) }
+      val materializedView = f(newInputs)
       val newState = m(stateKey to materializedView, inputsKey to newInputs)
 
       if (state.compareAndSet(currState, newState)) {
@@ -80,12 +69,19 @@ class ComputationReaction<I, O>(
 
   // init should be after state property.
   init {
-    for ((i, inputNode) in inputSignals.withIndex())
-      viewModelScope.launch {
-        inputNode.collect { newInput: I ->
-          recompute(newInput, i)
+    viewModelScope.launch(context) {
+      val inputs = deref(inputSignals)
+      state.value = m(
+        inputsKey to inputs,
+        stateKey to f(inputs)
+      )
+      for ((i, inputNode) in inputSignals.withIndex())
+        viewModelScope.launch(Dispatchers.Default) {
+          inputNode.collect { newInput: I ->
+            recompute(newInput, i)
+          }
         }
-      }
+    }
   }
 
   override fun deref(state: State<IPersistentMap<Any, Any?>>): O =

--- a/recompose/src/main/java/com/github/whyrising/recompose/subs/subs.kt
+++ b/recompose/src/main/java/com/github/whyrising/recompose/subs/subs.kt
@@ -75,9 +75,9 @@ inline fun <I, O> regCompSubscription(
   crossinline signalsFn: (
     queryVec: Query
   ) -> IPersistentVector<Reaction<I>>,
-  initial: O?,
+  initial: O,
   context: CoroutineContext,
-  crossinline computationFn: (
+  crossinline computationFn: suspend (
     subscriptions: IPersistentVector<I>,
     queryVec: Query
   ) -> O

--- a/recompose/src/test/java/com/github/whyrising/recompose/ComputationReactionTest.kt
+++ b/recompose/src/test/java/com/github/whyrising/recompose/ComputationReactionTest.kt
@@ -9,7 +9,6 @@ import com.github.whyrising.recompose.subs.deref
 import com.github.whyrising.recompose.subs.inputsKey
 import com.github.whyrising.recompose.subs.stateKey
 import com.github.whyrising.y.core.collections.IPersistentVector
-import com.github.whyrising.y.core.get
 import com.github.whyrising.y.core.inc
 import com.github.whyrising.y.core.l
 import com.github.whyrising.y.core.m
@@ -21,6 +20,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -29,6 +29,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlin.time.Duration.Companion.seconds
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ComputationReactionTest : FreeSpec({
   val testDispatcher = StandardTestDispatcher()
   Dispatchers.setMain(testDispatcher)
@@ -36,51 +37,26 @@ class ComputationReactionTest : FreeSpec({
   "ctor" - {
     "default values" {
       val defaultVal = 0
-      val f = { _: IPersistentVector<Int> -> defaultVal }
-      val reaction = ComputationReaction(v(), testDispatcher, null, f)
+
+      val reaction = ComputationReaction(
+        inputSignals = v(),
+        context = testDispatcher,
+        initial = defaultVal
+      ) { _: IPersistentVector<Int> ->
+        defaultVal
+      }
 
       reaction.isFresh.deref().shouldBeTrue()
       reaction.id shouldBe "rx${reaction.hashCode()}"
-      reaction.state.value shouldBe m(
-        stateKey to defaultVal,
-        "input" to v<Int>()
-      )
-    }
-
-    "when initial is null, value should be calculated through f" {
-      val f = { _: IPersistentVector<Int> -> -1 }
-      val reaction = ComputationReaction(v(), testDispatcher, null, f)
-
-      reaction.deref() shouldBeExactly -1
-    }
-
-    "when initial is not null, value should be calculated through f" {
-      val initial = 0
-      val f = { _: IPersistentVector<Int> -> -1 }
-      val reaction = ComputationReaction(v(), testDispatcher, initial, f)
-
-      reaction.deref() shouldBeExactly initial
-    }
-
-    "when reaction is first created, state should be lazy" {
-      var x = 0
-      val f = { _: IPersistentVector<Int> ->
-        x = 1
-        x
-      }
-
-      val reaction = ComputationReaction(v(), testDispatcher, null, f)
-
-      x shouldBe 0 // f not called yet
-      reaction.state.value[stateKey] shouldBe 1
-      x shouldBe 1
+      reaction.state.value shouldBe m(stateKey to defaultVal)
     }
   }
 
   "deref()" {
     val defaultVal = 0
     val f = { _: IPersistentVector<Int> -> defaultVal }
-    val reaction = ComputationReaction(v(), testDispatcher, null, f)
+    val reaction =
+      ComputationReaction(v(), testDispatcher, initial = defaultVal, f = f)
 
     reaction.deref() shouldBe defaultVal
   }
@@ -90,7 +66,7 @@ class ComputationReactionTest : FreeSpec({
       ComputationReaction(
         v(),
         testDispatcher,
-        null
+        -1
       ) { _: IPersistentVector<Int> -> 1 }
     val f: (ReactionBase<*, *>) -> Unit = { }
 
@@ -106,7 +82,7 @@ class ComputationReactionTest : FreeSpec({
         """ {
       var isDisposed = false
       val reaction =
-        ComputationReaction<Int, Int>(v(), testDispatcher, null) { 0 }
+        ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 0 }
       val f: (ReactionBase<*, *>) -> Unit = { isDisposed = true }
       reaction.addOnDispose(f)
       reaction.state.value
@@ -119,7 +95,7 @@ class ComputationReactionTest : FreeSpec({
 
     "when no dispose functions added and scope not active, skip " {
       val reaction =
-        ComputationReaction<Int, Int>(v(), testDispatcher, null) { 0 }
+        ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 0 }
 
       reaction.dispose()
 
@@ -130,7 +106,7 @@ class ComputationReactionTest : FreeSpec({
   "onCleared() should call dispose" {
     var isDisposed = false
     val reaction =
-      ComputationReaction<Int, Int>(v(), testDispatcher, null) { 0 }
+      ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 0 }
     val f: (ReactionBase<*, *>) -> Unit = { isDisposed = true }
     reaction.addOnDispose(f)
     reaction.state.value
@@ -144,15 +120,18 @@ class ComputationReactionTest : FreeSpec({
   "recompute()" - {
     "should recompute the reaction using the new arg" {
       runTest {
+        val initial = -1
         val input1 = ExtractorReaction(RAtom(1)) { it }
         val input2 = ExtractorReaction(RAtom(2)) { it }
         val reaction = ComputationReaction(
           inputSignals = v(input1, input2),
           context = testDispatcher,
-          initial = null
+          initial = initial
         ) { (a, b) ->
           a.inc() + b.inc()
         }
+
+        advanceUntilIdle()
 
         reaction.deref() shouldBeExactly 5
 
@@ -167,79 +146,105 @@ class ComputationReactionTest : FreeSpec({
     }
 
     "when the same arg passed it should not recompute" {
-      val r1 =
-        ComputationReaction<Int, Int>(v(), testDispatcher, null) { 1 }
-      val r2 =
-        ComputationReaction<Int, Int>(v(), testDispatcher, null) { 2 }
-      val reaction =
-        ComputationReaction(v(r1, r2), testDispatcher, null) { (a, b) ->
-          a.inc() + b.inc()
-        }
-      reaction.deref() shouldBe 5
+      runTest {
+        val initial = -1
+        val r1 =
+          ComputationReaction<Int, Int>(v(), testDispatcher, initial) { 1 }
+        val r2 =
+          ComputationReaction<Int, Int>(v(), testDispatcher, initial) { 2 }
+        val reaction =
+          ComputationReaction(v(r1, r2), testDispatcher, initial) { (a, b) ->
+            a.inc() + b.inc()
+          }
+        advanceUntilIdle()
 
-      reaction.recompute(1, 0)
+        reaction.deref() shouldBe 5
 
-      reaction.deref() shouldBe 5
+        reaction.recompute(1, 0)
+
+        reaction.deref() shouldBe 5
+      }
     }
   }
 
   "deref(subscriptions) should return a vector of dereferenced reactions" {
-    val reaction1 =
-      ComputationReaction<Int, Int>(v(), testDispatcher, null) { 1 }
-    val reaction2 =
-      ComputationReaction<Int, Int>(v(), testDispatcher, null) { 2 }
-    val reaction3 =
-      ComputationReaction<Int, Int>(v(), testDispatcher, null) { 3 }
+    runTest {
+      val reaction1 =
+        ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 1 }
+      val reaction2 =
+        ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 2 }
+      val reaction3 =
+        ComputationReaction<Int, Int>(v(), testDispatcher, -1) { 3 }
 
-    deref(v(reaction1, reaction2, reaction3)) shouldBe v(1, 2, 3)
+      advanceUntilIdle()
+
+      deref(v(reaction1, reaction2, reaction3)) shouldBe v(1, 2, 3)
+    }
   }
 
   "input signals" - {
     "one input signal" {
-      val input = ExtractorReaction(RAtom(0)) { 0 }
-      val r =
-        ComputationReaction(v(input), testDispatcher, null) { args ->
+      runTest {
+        val input = ExtractorReaction(RAtom(0)) { 0 }
+        val r = ComputationReaction(
+          inputSignals = v(input),
+          context = testDispatcher,
+          initial = -1,
+          context2 = testDispatcher
+        ) { args ->
           inc(args[0])
         }
-      input.state.emit(5)
+        advanceUntilIdle()
 
-      r.deref() shouldBe 6
+        input.state.emit(5)
+
+        advanceUntilIdle()
+
+        r.deref() shouldBe 6
+      }
     }
 
     "multiple input signals" {
-      val input1 = ExtractorReaction(RAtom(0)) { 0 }
-      val input2 = ExtractorReaction(RAtom(0)) { 0 }
-      val node = ComputationReaction(
-        inputSignals = v(input1, input2),
-        context = testDispatcher,
-        initial = null
-      ) { (a, b) ->
-        inc(a + b)
+      runTest {
+        val input1 = ExtractorReaction(RAtom(0)) { 0 }
+        val input2 = ExtractorReaction(RAtom(0)) { 0 }
+        val node = ComputationReaction(
+          inputSignals = v(input1, input2),
+          context = testDispatcher,
+          initial = -1,
+          context2 = testDispatcher
+        ) { (a, b) ->
+          inc(a + b)
+        }
+        advanceUntilIdle()
+
+        input1.state.emit(3)
+        input2.state.emit(5)
+        advanceUntilIdle()
+
+        node.deref() shouldBe 9
       }
-
-      input1.state.emit(3)
-      input2.state.emit(5)
-
-      node.deref() shouldBe 9
     }
 
     "parallel incoming input signals" {
       continually(duration = 60.seconds) {
         runTest {
+          val standardTestDispatcher = StandardTestDispatcher()
           val input1 = ExtractorReaction(RAtom(0)) { 0 }
           val input2 = ExtractorReaction(RAtom(0)) { 0 }
           val r = ComputationReaction(
             inputSignals = v(input1, input2),
-            context = StandardTestDispatcher(),
-            initial = -1
+            context = standardTestDispatcher,
+            initial = -1,
+            context2 = standardTestDispatcher
           ) { (a, b) ->
             inc(a + b)
           }
 
-          multiThreadedRun(100, 100, StandardTestDispatcher()) {
+          multiThreadedRun(100, 100, standardTestDispatcher) {
             input1.state.update { it.inc() }
           }
-          multiThreadedRun(100, 100, StandardTestDispatcher()) {
+          multiThreadedRun(100, 100, standardTestDispatcher) {
             input2.state.update { it.inc() }
           }
           advanceUntilIdle()


### PR DESCRIPTION
Running them on the Main thread caused some animations to stutter (e.g. Circular Progress Loader). Providing a placeholder value and calculating the actual value asynchronously on Dispatchers.Default gives the UI the chance to do what it does best, render graphics smoothly.